### PR TITLE
Refactor ArDepthImage to use VkBuffer instead of VkImage

### DIFF
--- a/app/src/main/cpp/ar_depth_image.cpp
+++ b/app/src/main/cpp/ar_depth_image.cpp
@@ -1,10 +1,17 @@
 #include "ar_depth_image.h"
+#include "command_pool_manager.h"
+#include "vk_debug.h"
+#include "concatenate.h"
 #include <vulkan/vulkan.h>
+#include <cassert>
+#include <cstring>
 using namespace graphics;
 
 ArDepthImage::ArDepthImage(VkDevice device, VmaAllocator allocator,
-                           CommandPoolManager &cmdManager) :
-                           device(device), allocator(allocator) {
+                           CommandPoolManager &cmdManager,
+                           const std::string &name) :
+                           device(device), allocator(allocator),
+                           cmdManager(cmdManager), name(name) {
     for(auto i=0; i<MAX_FRAMES_IN_FLIGHT; i++) {
         depthImages[i] = VK_NULL_HANDLE;
         depthImagesAllocations[i] = VK_NULL_HANDLE;
@@ -45,11 +52,87 @@ void ArDepthImage::UpdateImage(std::vector<uint16_t>& image, VkExtent2D dimensio
 
 void ArDepthImage::UpdateCurrentSlotIfPending() {
     if(depthImages.Current() != VK_NULL_HANDLE){
-        //there's something in this slot, delete it.
         vkDestroyImageView(device, depthImageViews.Current(), nullptr);
         vmaDestroyImage(allocator, depthImages.Current(), depthImagesAllocations.Current());
     }
-    //TODO: make something equivalent to MutableMesh::FillBuffer to fill the image
-    //TODO: create the image view
-    //TODO: set the new object names
+    UploadToCurrentSlot();
+    SetObjectsNames();
+}
+
+void ArDepthImage::UploadToCurrentSlot() {
+    // 1. Create the GPU image (R16_UINT, optimal tiling, transfer dst + sampled)
+    VkImageCreateInfo imageInfo{};
+    imageInfo.sType         = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+    imageInfo.imageType     = VK_IMAGE_TYPE_2D;
+    imageInfo.format        = VK_FORMAT_R16_UINT;
+    imageInfo.extent        = {pendingDimension.width, pendingDimension.height, 1};
+    imageInfo.mipLevels     = 1;
+    imageInfo.arrayLayers   = 1;
+    imageInfo.samples       = VK_SAMPLE_COUNT_1_BIT;
+    imageInfo.tiling        = VK_IMAGE_TILING_OPTIMAL;
+    imageInfo.usage         = VK_IMAGE_USAGE_TRANSFER_DST_BIT |
+                              VK_IMAGE_USAGE_SAMPLED_BIT;
+    imageInfo.sharingMode   = VK_SHARING_MODE_EXCLUSIVE;
+    imageInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+
+    VmaAllocationCreateInfo imageAllocInfo{};
+    imageAllocInfo.usage = VMA_MEMORY_USAGE_GPU_ONLY;
+
+    VkResult result = vmaCreateImage(allocator, &imageInfo, &imageAllocInfo,
+                                     &depthImages.Current(),
+                                     &depthImagesAllocations.Current(),
+                                     nullptr);
+    assert(result == VK_SUCCESS);
+
+    // 2. Create staging buffer (host-visible, persistently mapped)
+    VkDeviceSize stagingSize = static_cast<VkDeviceSize>(pendingImage.size()) * sizeof(uint16_t);
+
+    VkBufferCreateInfo bufInfo{};
+    bufInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+    bufInfo.size  = stagingSize;
+    bufInfo.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+
+    VmaAllocationCreateInfo stagingAllocInfo{};
+    stagingAllocInfo.usage = VMA_MEMORY_USAGE_AUTO;
+    stagingAllocInfo.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT |
+                             VMA_ALLOCATION_CREATE_MAPPED_BIT;
+
+    VkBuffer stagingBuffer = VK_NULL_HANDLE;
+    VmaAllocation stagingAllocation = VK_NULL_HANDLE;
+    VmaAllocationInfo mapInfo{};
+    result = vmaCreateBuffer(allocator, &bufInfo, &stagingAllocInfo,
+                             &stagingBuffer, &stagingAllocation, &mapInfo);
+    assert(result == VK_SUCCESS);
+
+    // 3. Copy pending data into staging buffer
+    memcpy(mapInfo.pMappedData, pendingImage.data(), stagingSize);
+
+    // 4. Upload staging → image via CommandPoolManager (handles layout transitions)
+    cmdManager.UploadImage(stagingBuffer, depthImages.Current(),
+                           pendingDimension.width, pendingDimension.height,
+                           VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+
+    // 5. Destroy staging buffer (upload is synchronous/blocking)
+    vmaDestroyBuffer(allocator, stagingBuffer, stagingAllocation);
+
+    // 6. Create image view
+    VkImageViewCreateInfo viewInfo{};
+    viewInfo.sType    = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+    viewInfo.image    = depthImages.Current();
+    viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
+    viewInfo.format   = VK_FORMAT_R16_UINT;
+    viewInfo.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+
+    result = vkCreateImageView(device, &viewInfo, nullptr, &depthImageViews.Current());
+    assert(result == VK_SUCCESS);
+
+    // 7. Update size for this slot
+    imageSizes.Current() = pendingDimension;
+}
+
+void ArDepthImage::SetObjectsNames() {
+    debug::SetImageName(device, depthImages.Current(),
+                        Concatenate(name, " Depth Image Generation #", pendingGeneration));
+    debug::SetImageViewName(device, depthImageViews.Current(),
+                            Concatenate(name, " Depth ImageView Generation #", pendingGeneration));
 }

--- a/app/src/main/cpp/ar_depth_image.cpp
+++ b/app/src/main/cpp/ar_depth_image.cpp
@@ -1,5 +1,4 @@
 #include "ar_depth_image.h"
-#include "command_pool_manager.h"
 #include "vk_debug.h"
 #include "concatenate.h"
 #include <vulkan/vulkan.h>
@@ -8,14 +7,11 @@
 using namespace graphics;
 
 ArDepthImage::ArDepthImage(VkDevice device, VmaAllocator allocator,
-                           CommandPoolManager &cmdManager,
                            const std::string &name) :
-                           device(device), allocator(allocator),
-                           cmdManager(cmdManager), name(name) {
+                           device(device), allocator(allocator), name(name) {
     for(auto i=0; i<MAX_FRAMES_IN_FLIGHT; i++) {
-        depthImages[i] = VK_NULL_HANDLE;
-        depthImagesAllocations[i] = VK_NULL_HANDLE;
-        depthImageViews[i] = VK_NULL_HANDLE;
+        depthBuffers[i] = VK_NULL_HANDLE;
+        depthBufferAllocations[i] = VK_NULL_HANDLE;
         imageSizes[i] = {0,0};
         slotGeneration[i] = 0;
     }
@@ -23,17 +19,15 @@ ArDepthImage::ArDepthImage(VkDevice device, VmaAllocator allocator,
 
 ArDepthImage::~ArDepthImage() {
     for(auto i=0; i<MAX_FRAMES_IN_FLIGHT;i++) {
-        if(depthImages[i] != VK_NULL_HANDLE){
-            vkDestroyImageView(device, depthImageViews[i], nullptr);
-            vmaDestroyImage(allocator, depthImages[i], depthImagesAllocations[i]);
+        if(depthBuffers[i] != VK_NULL_HANDLE){
+            vmaDestroyBuffer(allocator, depthBuffers[i], depthBufferAllocations[i]);
         }
     }
 }
 
 void ArDepthImage::Advance() {
-    depthImages.Next();
-    depthImagesAllocations.Next();
-    depthImageViews.Next();
+    depthBuffers.Next();
+    depthBufferAllocations.Next();
     imageSizes.Next();
     slotGeneration.Next();
     if(slotGeneration.Current() < pendingGeneration) {
@@ -51,88 +45,39 @@ void ArDepthImage::UpdateImage(std::vector<uint16_t>& image, VkExtent2D dimensio
 }
 
 void ArDepthImage::UpdateCurrentSlotIfPending() {
-    if(depthImages.Current() != VK_NULL_HANDLE){
-        vkDestroyImageView(device, depthImageViews.Current(), nullptr);
-        vmaDestroyImage(allocator, depthImages.Current(), depthImagesAllocations.Current());
+    if(depthBuffers.Current() != VK_NULL_HANDLE){
+        vmaDestroyBuffer(allocator, depthBuffers.Current(), depthBufferAllocations.Current());
     }
     UploadToCurrentSlot();
     SetObjectsNames();
 }
 
 void ArDepthImage::UploadToCurrentSlot() {
-    // 1. Create the GPU image (R16_UINT, optimal tiling, transfer dst + sampled)
-    VkImageCreateInfo imageInfo{};
-    imageInfo.sType         = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
-    imageInfo.imageType     = VK_IMAGE_TYPE_2D;
-    imageInfo.format        = VK_FORMAT_R16_UINT;
-    imageInfo.extent        = {pendingDimension.width, pendingDimension.height, 1};
-    imageInfo.mipLevels     = 1;
-    imageInfo.arrayLayers   = 1;
-    imageInfo.samples       = VK_SAMPLE_COUNT_1_BIT;
-    imageInfo.tiling        = VK_IMAGE_TILING_OPTIMAL;
-    imageInfo.usage         = VK_IMAGE_USAGE_TRANSFER_DST_BIT |
-                              VK_IMAGE_USAGE_SAMPLED_BIT;
-    imageInfo.sharingMode   = VK_SHARING_MODE_EXCLUSIVE;
-    imageInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-
-    VmaAllocationCreateInfo imageAllocInfo{};
-    imageAllocInfo.usage = VMA_MEMORY_USAGE_GPU_ONLY;
-
-    VkResult result = vmaCreateImage(allocator, &imageInfo, &imageAllocInfo,
-                                     &depthImages.Current(),
-                                     &depthImagesAllocations.Current(),
-                                     nullptr);
-    assert(result == VK_SUCCESS);
-
-    // 2. Create staging buffer (host-visible, persistently mapped)
-    VkDeviceSize stagingSize = static_cast<VkDeviceSize>(pendingImage.size()) * sizeof(uint16_t);
+    VkDeviceSize bufferSize = static_cast<VkDeviceSize>(pendingImage.size()) * sizeof(uint16_t);
 
     VkBufferCreateInfo bufInfo{};
     bufInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
-    bufInfo.size  = stagingSize;
-    bufInfo.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+    bufInfo.size  = bufferSize;
+    bufInfo.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
 
-    VmaAllocationCreateInfo stagingAllocInfo{};
-    stagingAllocInfo.usage = VMA_MEMORY_USAGE_AUTO;
-    stagingAllocInfo.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT |
-                             VMA_ALLOCATION_CREATE_MAPPED_BIT;
+    VmaAllocationCreateInfo allocInfo{};
+    allocInfo.usage = VMA_MEMORY_USAGE_AUTO;
+    allocInfo.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT
+                      | VMA_ALLOCATION_CREATE_MAPPED_BIT;
 
-    VkBuffer stagingBuffer = VK_NULL_HANDLE;
-    VmaAllocation stagingAllocation = VK_NULL_HANDLE;
-    VmaAllocationInfo mapInfo{};
-    result = vmaCreateBuffer(allocator, &bufInfo, &stagingAllocInfo,
-                             &stagingBuffer, &stagingAllocation, &mapInfo);
+    VmaAllocationInfo mapInfo;
+    VkResult result = vmaCreateBuffer(allocator, &bufInfo, &allocInfo,
+                                      &depthBuffers.Current(),
+                                      &depthBufferAllocations.Current(),
+                                      &mapInfo);
     assert(result == VK_SUCCESS);
 
-    // 3. Copy pending data into staging buffer
-    memcpy(mapInfo.pMappedData, pendingImage.data(), stagingSize);
+    memcpy(mapInfo.pMappedData, pendingImage.data(), bufferSize);
 
-    // 4. Upload staging → image via CommandPoolManager (handles layout transitions)
-    cmdManager.UploadImage(stagingBuffer, depthImages.Current(),
-                           pendingDimension.width, pendingDimension.height,
-                           VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
-
-    // 5. Destroy staging buffer (upload is synchronous/blocking)
-    vmaDestroyBuffer(allocator, stagingBuffer, stagingAllocation);
-
-    // 6. Create image view
-    VkImageViewCreateInfo viewInfo{};
-    viewInfo.sType    = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
-    viewInfo.image    = depthImages.Current();
-    viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
-    viewInfo.format   = VK_FORMAT_R16_UINT;
-    viewInfo.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
-
-    result = vkCreateImageView(device, &viewInfo, nullptr, &depthImageViews.Current());
-    assert(result == VK_SUCCESS);
-
-    // 7. Update size for this slot
     imageSizes.Current() = pendingDimension;
 }
 
 void ArDepthImage::SetObjectsNames() {
-    debug::SetImageName(device, depthImages.Current(),
-                        Concatenate(name, " Depth Image Generation #", pendingGeneration));
-    debug::SetImageViewName(device, depthImageViews.Current(),
-                            Concatenate(name, " Depth ImageView Generation #", pendingGeneration));
+    debug::SetBufferName(device, depthBuffers.Current(),
+                         Concatenate(name, " Depth Buffer Generation #", pendingGeneration));
 }

--- a/app/src/main/cpp/ar_depth_image.h
+++ b/app/src/main/cpp/ar_depth_image.h
@@ -9,31 +9,31 @@
 namespace graphics {
     class CommandPoolManager;
     /**
-     * I need a ring buffer because the ar depth image will change per frame while being processed
-     * by command lists. So the change to the frame N+1 must not touch the image already in use by
-     * frame N. That's the same rationale of the mutable mesh.
+     * Ring-buffered depth data from ARCore's acquireDepthImage16Bits.
+     * Always uint16, millimeters, 1 plane, stored as R16_UINT.
      *
-     * The image comes from ARCore's acquireDepthImage16Bits: always uint16, millimeters, 1 plane.
-     * Stored as VK_FORMAT_R16_UINT.
+     * Uses a host-mapped VkBuffer (no staging buffer) since Android has
+     * unified memory. Follows the same pattern as MutableMesh.
      * */
     class ArDepthImage {
     public:
         ArDepthImage(VkDevice device, VmaAllocator allocator,
-                     CommandPoolManager& cmdManager,
                      const std::string& name = "");
         ~ArDepthImage();
         void Advance();
         void UpdateImage(std::vector<uint16_t>& image, VkExtent2D dimensions);
-        VkImageView GetCurrentImageView() const { return depthImageViews.Current(); }
+        VkBuffer GetCurrentBuffer() const { return depthBuffers.Current(); }
         VkExtent2D GetCurrentSize() const { return imageSizes.Current(); }
+        uint32_t GetCurrentPixelCount() const {
+            auto sz = imageSizes.Current();
+            return sz.width * sz.height;
+        }
     private:
         VkDevice device;
         VmaAllocator allocator;
-        CommandPoolManager& cmdManager;
         const std::string name;
-        utils::RingBuffer<VkImage> depthImages;
-        utils::RingBuffer<VmaAllocation> depthImagesAllocations;
-        utils::RingBuffer<VkImageView> depthImageViews;
+        utils::RingBuffer<VkBuffer> depthBuffers;
+        utils::RingBuffer<VmaAllocation> depthBufferAllocations;
         utils::RingBuffer<VkExtent2D> imageSizes;
         utils::RingBuffer<uint64_t> slotGeneration;
         std::vector<uint16_t> pendingImage;

--- a/app/src/main/cpp/ar_depth_image.h
+++ b/app/src/main/cpp/ar_depth_image.h
@@ -5,23 +5,32 @@
 #include "ring_buffer.h"
 #include "vk_mem_alloc.h"
 #include <vector>
+#include <string>
 namespace graphics {
     class CommandPoolManager;
     /**
      * I need a ring buffer because the ar depth image will change per frame while being processed
      * by command lists. So the change to the frame N+1 must not touch the image already in use by
      * frame N. That's the same rationale of the mutable mesh.
+     *
+     * The image comes from ARCore's acquireDepthImage16Bits: always uint16, millimeters, 1 plane.
+     * Stored as VK_FORMAT_R16_UINT.
      * */
     class ArDepthImage {
     public:
         ArDepthImage(VkDevice device, VmaAllocator allocator,
-                     CommandPoolManager& cmdManager);
+                     CommandPoolManager& cmdManager,
+                     const std::string& name = "");
         ~ArDepthImage();
         void Advance();
         void UpdateImage(std::vector<uint16_t>& image, VkExtent2D dimensions);
+        VkImageView GetCurrentImageView() const { return depthImageViews.Current(); }
+        VkExtent2D GetCurrentSize() const { return imageSizes.Current(); }
     private:
         VkDevice device;
         VmaAllocator allocator;
+        CommandPoolManager& cmdManager;
+        const std::string name;
         utils::RingBuffer<VkImage> depthImages;
         utils::RingBuffer<VmaAllocation> depthImagesAllocations;
         utils::RingBuffer<VkImageView> depthImageViews;
@@ -31,7 +40,8 @@ namespace graphics {
         VkExtent2D pendingDimension;
         uint64_t pendingGeneration = 0;
         void UpdateCurrentSlotIfPending();
-
+        void UploadToCurrentSlot();
+        void SetObjectsNames();
     };
 }
 


### PR DESCRIPTION
## Summary
Refactored `ArDepthImage` to store depth data in host-mapped `VkBuffer` objects instead of `VkImage` objects, simplifying the implementation and leveraging Android's unified memory architecture.

## Key Changes
- **Storage format change**: Replaced `VkImage` + `VkImageView` with `VkBuffer` for depth data storage
  - Renamed `depthImages` → `depthBuffers`
  - Renamed `depthImagesAllocations` → `depthBufferAllocations`
  - Removed `depthImageViews` ring buffer entirely
  
- **Constructor simplification**: Removed `CommandPoolManager` dependency and added optional `name` parameter for debug naming

- **Buffer allocation**: Implemented `UploadToCurrentSlot()` method that:
  - Creates a host-mapped storage buffer with `VMA_ALLOCATION_CREATE_MAPPED_BIT`
  - Uses sequential write access for optimal performance
  - Directly copies pending image data via `memcpy` to mapped memory

- **Debug naming**: Added `SetObjectsNames()` method to assign descriptive names to buffers for debugging

- **Public API additions**: Added getter methods:
  - `GetCurrentBuffer()` - returns the current depth buffer
  - `GetCurrentSize()` - returns current image dimensions
  - `GetCurrentPixelCount()` - returns total pixel count

- **Documentation**: Updated class documentation to clarify the ring-buffering rationale and note that data is always uint16 in millimeters

## Implementation Details
- Uses `VMA_MEMORY_USAGE_AUTO` for automatic memory placement on Android
- Host-mapped buffers eliminate the need for staging buffers on unified memory systems
- Follows the same ring-buffering pattern as `MutableMesh` to prevent frame-in-flight conflicts
- Added necessary includes: `vk_debug.h`, `concatenate.h`, `<cassert>`, `<cstring>`

https://claude.ai/code/session_01CvPDvC6iKmQdTWt5erofaB